### PR TITLE
Enhance setup script CLI and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ This repository contains my complete development environment configuration with 
 - **[1Password CLI](https://developer.1password.com/docs/cli)** - Password and secrets management
 - **Homebrew Package Manager Script** - Custom Python script for package management
 
+### ☁️ Cloud & Infrastructure
+- **[AWS CLI](https://aws.amazon.com/cli/)** - AWS management from the terminal
+- **[k9s](https://k9scli.io/)** - Terminal UI for Kubernetes clusters
+- **[kubectx](https://github.com/ahmetb/kubectx)** - Switch between Kubernetes contexts and namespaces
+- **[Tunnelblick](https://tunnelblick.net/)** - OpenVPN client for macOS
+
+### 🔄 Runtime & Package Managers
+- **[nvm](https://github.com/nvm-sh/nvm)** - Node.js version manager
+- **[Yarn](https://yarnpkg.com/)** - JavaScript package manager
+- **[PDM](https://pdm.fming.dev/)** - Python package and environment manager
+
 ### ⌨️ Hardware Configuration
 - **[Glove80](https://www.moergo.com/collections/glove80-keyboards)** - Ergonomic keyboard layout and configuration
 
@@ -80,7 +91,7 @@ git clone https://github.com/katticot-ledger/.config.git ~/.config
 
 #### Option A: Automated Installation (Recommended)
 
-Use the included Python installation script for an interactive setup:
+Use the included Python installation script for an interactive setup or direct CLI control:
 
 ```bash
 # Run the comprehensive installation tool
@@ -88,10 +99,26 @@ cd ~/.config
 python3 main.py
 ```
 
-The script provides:
-- 📦 Install all packages at once
-- 📋 List all available packages
-- 🔧 Post-installation setup automation
+The script now supports both an interactive menu and command-line flags:
+
+```
+Usage: python3 main.py [options]
+
+Optional arguments:
+  --list             List categories and packages
+  --install CATEGORY Install a single category (can be repeated)
+  --install-all      Install every category without prompts
+  --post-install     Run the post-installation helpers (bun, pnpm, fish shell)
+  --update-brew      Run `brew update` and upgrade installed formulae
+```
+
+Interactive mode (run without flags) lets you:
+
+- 📦 Install every category
+- 🗂️ Install a single category
+- 📋 List packages before installing
+- 🔧 Run the post-install helpers (bun, pnpm, fish shell)
+- 🔄 Update Homebrew
 
 #### Option B: Manual Installation by Category
 
@@ -114,6 +141,10 @@ gh extension install github/gh-copilot
 gh extension install dlvhdr/gh-dash
 brew install --cask google-cloud-sdk
 
+# ☁️ Cloud & Infrastructure
+brew install awscli k9s kubectx
+brew install --cask tunnelblick
+
 # 🪟 Window Management (macOS)
 brew install koekeishiya/formulae/yabai
 brew install koekeishiya/formulae/skhd
@@ -128,7 +159,10 @@ brew install wtfutil
 brew install --cask raycast
 brew install 1password-cli
 
-# JavaScript Runtime & Package Managers
+# 🔄 Runtime & Package Managers
+brew install nvm yarn pdm
+
+# JavaScript Runtime (alternate install method)
 curl -fsSL https://bun.sh/install | bash
 npm install -g pnpm
 

--- a/main.py
+++ b/main.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
-"""
-Development Environment Setup Tool
-Installs and manages tools configured in ~/.config
-"""
+"""Interactive and CLI tooling for bootstrapping this dotfiles repo."""
 
-import os
+import argparse
 import subprocess
 import sys
-from typing import Dict, List, Set
+from typing import Dict, Iterable, List
 
 
 class Colors:
@@ -26,8 +23,13 @@ class Colors:
 def run_command(command: str, check: bool = True) -> subprocess.CompletedProcess:
     """Run shell command with error handling"""
     try:
-        result = subprocess.run(command, shell=True, check=check, 
-                              capture_output=True, text=True)
+        result = subprocess.run(
+            command,
+            shell=True,
+            check=check,
+            capture_output=True,
+            text=True,
+        )
         return result
     except subprocess.CalledProcessError as e:
         print(f"{Colors.RED}Error running command: {command}{Colors.END}")
@@ -51,23 +53,23 @@ def install_homebrew():
     print(f"{Colors.GREEN}Homebrew installed successfully!{Colors.END}")
 
 
-def install_packages(packages: Dict[str, List[str]], category: str = None):
-    """Install packages by category"""
+def install_packages(packages: Dict[str, List[str]], categories: Iterable[str] = None) -> None:
+    """Install packages for the provided categories."""
     if not check_brew_installed():
         install_homebrew()
-    
-    categories_to_install = [category] if category else packages.keys()
-    
+
+    categories_to_install = list(packages.keys()) if categories is None else list(categories)
+
     for cat in categories_to_install:
         if cat not in packages:
             print(f"{Colors.RED}Category '{cat}' not found!{Colors.END}")
             continue
-            
-        print(f"\n{Colors.CYAN}{Colors.BOLD}📦 Installing {cat}...{Colors.END}")
-        
+
+        print(f"\n{Colors.CYAN}{Colors.BOLD}📦 Installing {cat}{Colors.END}")
+
         for package_info in packages[cat]:
             package, install_type = package_info.split(":")
-            
+
             if install_type == "brew":
                 cmd = f"brew install {package}"
             elif install_type == "cask":
@@ -78,10 +80,10 @@ def install_packages(packages: Dict[str, List[str]], category: str = None):
                 cmd = f"gh extension install {package}"
             else:
                 cmd = package  # Custom command
-            
+
             print(f"  Installing {package}...")
             result = run_command(cmd, check=False)
-            
+
             if result.returncode == 0:
                 print(f"  {Colors.GREEN}✓ {package} installed{Colors.END}")
             else:
@@ -114,110 +116,226 @@ def update_package_list(new_package: str, category: str, install_type: str):
     print(f"{Colors.GREEN}Package {new_package} added to {category} (manual edit required){Colors.END}")
 
 
-def main():
-    """Main function with comprehensive package management"""
-    
-    # Comprehensive package dictionary organized by category
-    PACKAGES = {
-        "🖥️ Terminal Emulators & Multiplexers": [
-            "ghostty:cask",
-            "kitty:brew", 
-            "wezterm:cask",
-            "tmux:brew"
-        ],
-        "🐚 Shell & Command Line": [
-            "fish:brew",
-            "starship:brew",
-            "atuin:brew", 
-            "broot:brew",
-            "eza:brew",
-            "fzf:brew",
-            "zoxide:brew",
-            "bat:brew",
-            "ripgrep:brew",
-            "dust:brew",
-            "bass:brew"
-        ],
-        "💻 Code Editors": [
-            "neovim:brew"
-        ],
-        "🔧 Development Tools": [
-            "git:brew",
-            "gh:brew",
-            "github/gh-copilot:gh",
-            "dlvhdr/gh-dash:gh",
-            "google-cloud-sdk:cask",
-            "lazygit:brew",
-            "jq:brew",
-            "cmake:brew",
-            "gnupg:brew"
-        ],
-        "🪟 Window Management (macOS)": [
-            "koekeishiya/formulae:tap",
-            "FelixKratz/formulae:tap", 
-            "yabai:brew",
-            "skhd:brew",
-            "sketchybar:brew"
-        ],
-        "📊 System Monitoring": [
-            "btop:brew",
-            "wtfutil:brew"
-        ],
-        "🚀 Productivity & Utilities": [
-            "raycast:cask",
-            "1password-cli:brew"
-        ],
-        "☁️ Cloud & Infrastructure": [
-            "awscli:brew",
-            "k9s:brew",
-            "kubectx:brew",
-            "tunnelblick:cask"
-        ],
-        "🔄 Runtime & Package Managers": [
-            "nvm:brew",
-            "yarn:brew",
-            "pdm:brew"
-        ]
-    }
-    
+PACKAGES: Dict[str, List[str]] = {
+    "🖥️ Terminal Emulators & Multiplexers": [
+        "ghostty:cask",
+        "kitty:brew",
+        "wezterm:cask",
+        "tmux:brew",
+    ],
+    "🐚 Shell & Command Line": [
+        "fish:brew",
+        "starship:brew",
+        "atuin:brew",
+        "broot:brew",
+        "eza:brew",
+        "fzf:brew",
+        "zoxide:brew",
+        "bat:brew",
+        "ripgrep:brew",
+        "dust:brew",
+        "bass:brew",
+    ],
+    "💻 Code Editors": [
+        "neovim:brew",
+    ],
+    "🔧 Development Tools": [
+        "git:brew",
+        "gh:brew",
+        "github/gh-copilot:gh",
+        "dlvhdr/gh-dash:gh",
+        "google-cloud-sdk:cask",
+        "lazygit:brew",
+        "jq:brew",
+        "cmake:brew",
+        "gnupg:brew",
+    ],
+    "🪟 Window Management (macOS)": [
+        "koekeishiya/formulae:tap",
+        "FelixKratz/formulae:tap",
+        "yabai:brew",
+        "skhd:brew",
+        "sketchybar:brew",
+    ],
+    "📊 System Monitoring": [
+        "btop:brew",
+        "wtfutil:brew",
+    ],
+    "🚀 Productivity & Utilities": [
+        "raycast:cask",
+        "1password-cli:brew",
+    ],
+    "☁️ Cloud & Infrastructure": [
+        "awscli:brew",
+        "k9s:brew",
+        "kubectx:brew",
+        "tunnelblick:cask",
+    ],
+    "🔄 Runtime & Package Managers": [
+        "nvm:brew",
+        "yarn:brew",
+        "pdm:brew",
+    ],
+}
+
+
+def list_packages(packages: Dict[str, List[str]], categories: Iterable[str] = None) -> None:
+    """Print packages, optionally scoped to a subset of categories."""
+    categories_to_list = list(packages.keys()) if categories is None else list(categories)
+
+    for cat in categories_to_list:
+        if cat not in packages:
+            print(f"{Colors.RED}Category '{cat}' not found!{Colors.END}")
+            continue
+
+        print(f"\n{Colors.CYAN}{cat}{Colors.END}")
+        for package_info in packages[cat]:
+            package_name, install_type = package_info.split(":")
+            print(f"  • {package_name} ({install_type})")
+
+
+def choose_category(packages: Dict[str, List[str]]) -> str:
+    """Prompt the user to select a single category for installation."""
+    categories = list(packages.keys())
+    print(f"\n{Colors.WHITE}{Colors.BOLD}Select a category to install:{Colors.END}")
+    for idx, category in enumerate(categories, start=1):
+        print(f"{idx}. {category}")
+
+    selection = input(f"\n{Colors.YELLOW}Enter number or name: {Colors.END}").strip()
+    if selection.isdigit():
+        index = int(selection) - 1
+        if 0 <= index < len(categories):
+            return categories[index]
+    elif selection in packages:
+        return selection
+
+    print(f"{Colors.RED}Invalid selection. Returning to main menu.{Colors.END}")
+    return ""
+
+
+def update_homebrew() -> None:
+    """Update Homebrew formulae and upgrade installed packages."""
+    if not check_brew_installed():
+        print(f"{Colors.RED}Homebrew is not installed. Install packages first.{Colors.END}")
+        return
+
+    print(f"\n{Colors.CYAN}{Colors.BOLD}🔄 Updating Homebrew...{Colors.END}")
+    for description, command in (
+        ("brew update", "brew update"),
+        ("brew upgrade", "brew upgrade"),
+        ("brew upgrade --cask", "brew upgrade --cask"),
+    ):
+        print(f"  {description}...")
+        result = run_command(command, check=False)
+        if result.returncode == 0:
+            print(f"  {Colors.GREEN}✓ {description} completed{Colors.END}")
+        else:
+            print(f"  {Colors.YELLOW}⚠ {description} may require manual review{Colors.END}")
+
+
+def parse_args() -> argparse.Namespace:
+    """Build the CLI argument parser."""
+    parser = argparse.ArgumentParser(description="Manage development environment packages")
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List available package categories and their contents",
+    )
+    parser.add_argument(
+        "--install",
+        metavar="CATEGORY",
+        action="append",
+        help="Install a specific category (can be passed multiple times)",
+    )
+    parser.add_argument(
+        "--install-all",
+        action="store_true",
+        help="Install every category",
+    )
+    parser.add_argument(
+        "--post-install",
+        action="store_true",
+        help="Run the post-installation helpers",
+    )
+    parser.add_argument(
+        "--update-brew",
+        action="store_true",
+        help="Run brew update and upgrade",
+    )
+    return parser.parse_args()
+
+
+def interactive_menu() -> None:
+    """Start the interactive TUI for managing the packages."""
     print(f"{Colors.CYAN}{Colors.BOLD}")
     print("=" * 60)
-    print("   🛠️  Development Environment Setup Tool  🛠️")  
+    print("   🛠️  Development Environment Setup Tool  🛠️")
     print("=" * 60)
     print(f"{Colors.END}")
-    
+
     while True:
         print(f"\n{Colors.WHITE}{Colors.BOLD}Available Actions:{Colors.END}")
         print("1. 📦 Install all packages")
-        print("2. 📋 List all packages")
-        print("3. 🔧 Run post-installation setup")
-        print("4. ❌ Exit")
-        
-        choice = input(f"\n{Colors.YELLOW}Enter your choice (1-4): {Colors.END}").strip()
-        
+        print("2. 🗂️ Install a single category")
+        print("3. 📋 List all packages")
+        print("4. 🔧 Run post-installation setup")
+        print("5. 🔄 Update Homebrew")
+        print("6. ❌ Exit")
+
+        choice = input(f"\n{Colors.YELLOW}Enter your choice (1-6): {Colors.END}").strip()
+
         if choice == "1":
             print(f"\n{Colors.MAGENTA}Installing all packages...{Colors.END}")
             install_packages(PACKAGES)
             post_install_setup()
-            
         elif choice == "2":
-            print(f"\n{Colors.WHITE}{Colors.BOLD}📋 Complete Package List:{Colors.END}")
-            for category, packages in PACKAGES.items():
-                print(f"\n{Colors.CYAN}{category}{Colors.END}")
-                for package_info in packages:
-                    package_name = package_info.split(":")[0]
-                    install_type = package_info.split(":")[1]
-                    print(f"  • {package_name} ({install_type})")
-                    
+            category = choose_category(PACKAGES)
+            if category:
+                install_packages(PACKAGES, categories=[category])
         elif choice == "3":
-            post_install_setup()
-            
+            print(f"\n{Colors.WHITE}{Colors.BOLD}📋 Complete Package List:{Colors.END}")
+            list_packages(PACKAGES)
         elif choice == "4":
+            post_install_setup()
+        elif choice == "5":
+            update_homebrew()
+        elif choice == "6":
             print(f"{Colors.GREEN}Goodbye! 👋{Colors.END}")
             break
-            
         else:
-            print(f"{Colors.RED}Invalid choice! Please enter 1-4.{Colors.END}")
+            print(f"{Colors.RED}Invalid choice! Please enter 1-6.{Colors.END}")
+
+
+def main() -> None:
+    """Entry point for CLI and interactive workflows."""
+
+    args = parse_args()
+    executed = False
+
+    if args.list:
+        list_packages(PACKAGES)
+        executed = True
+
+    if args.install_all:
+        install_packages(PACKAGES)
+        executed = True
+
+    if args.install:
+        install_packages(PACKAGES, categories=args.install)
+        executed = True
+
+    if args.post_install:
+        post_install_setup()
+        executed = True
+
+    if args.update_brew:
+        update_homebrew()
+        executed = True
+
+    if executed:
+        return
+
+    interactive_menu()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a command-line interface to `main.py` alongside the interactive menu
- allow installing individual categories, updating Homebrew, and listing packages in both CLI and TUI flows
- document the new script capabilities and expanded package categories in the README

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_687e205a6e8883278c084d3edc7d7639